### PR TITLE
Fix broken mailto link in contact page

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -7,7 +7,7 @@ share-title: Prima tás de bata | Contacte-nos
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 <script>enableSubmitContact = function(){ document.getElementById("submit_contact").disabled = false; }</script>
 
-Para qualquer pergunta, contacte-nos por email [primatasdebata@gmail.com](primatasdebata@gmail.com?subject=Contacto Prima tás de bata)
+Para qualquer pergunta, contacte-nos por email [primatasdebata@gmail.com](mailto:primatasdebata@gmail.com?subject=Contacto Prima tás de bata)
 
 
 


### PR DESCRIPTION
## Summary
Fixes the broken email link on the contact page by adding the missing `mailto:` protocol prefix.

## Changes
- Updated `contact.md:10` to include `mailto:` prefix in the email link

## Before
```markdown
[primatasdebata@gmail.com](primatasdebata@gmail.com?subject=Contacto Prima tás de bata)
```

## After
```markdown
[primatasdebata@gmail.com](mailto:primatasdebata@gmail.com?subject=Contacto Prima tás de bata)
```

## Impact
The email link will now properly open the user's default email client instead of being treated as a relative URL.

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)