### PR TITLE
Fix build failure: remove deleted custom_footer.html reference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,6 @@ defaults:
       path: ""
     values:
       layout: "page"
-      footer-extra: custom_footer.html
       nav-short: true
       share-description: "Prima tás de bata | Ciêncie e comunicação"
       share-img: "/assets/img/logo2.png"


### PR DESCRIPTION
## Summary
Fixes the Jekyll build failure caused by the previous PR (#16) which deleted `custom_footer.html` but left the reference in `_config.yml`.

## Error
The build was failing with:
```
Liquid Exception: Could not locate the included file 'custom_footer.html' 
in any of ["/github/workspace/_includes", ...]. 
Ensure it exists in one of those directories and is not a symlink 
as those are not allowed in safe mode.
```

## Changes
- Removed `footer-extra: custom_footer.html` from `_config.yml` (line 48)

## Impact
- Fixes the build failure
- Site will now build successfully without the newsletter footer

This completes the newsletter removal started in PR #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)