### PR TITLE
Fix Gemfile dependency warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gem 'github-pages', group: :jekyll_plugins
-
-gem "webrick", "~> 1.8"


### PR DESCRIPTION
## Summary
Fixes the build warning about Gemfile dependencies by removing the explicit `webrick` dependency.

## Warning Fixed
```
The github-pages gem can't satisfy your Gemfile's dependencies. 
If you want to use a different Jekyll version or need additional 
dependencies, consider building Jekyll site with GitHub Actions
```

## Changes
- Removed `gem "webrick", "~> 1.8"` from Gemfile

## Explanation
The `github-pages` gem already manages all required dependencies, including webrick. Having an explicit webrick dependency in the Gemfile can cause version conflicts and triggers this warning.

By removing the explicit dependency, we let the github-pages gem handle all dependencies correctly.

## Impact
- Eliminates build warning
- Cleaner dependency management
- No functional changes to the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)