### PR TITLE
Remove emphasized social proof styling, use simple sentence format

### DIFF
--- a/assets/css/primatasdebata.css
+++ b/assets/css/primatasdebata.css
@@ -101,28 +101,6 @@ footer a {
   transform: translateY(-2px);
 }
 
-/* Social Proof */
-.social-proof {
-  margin: 2rem 0;
-  text-align: center;
-}
-
-.community-size {
-  display: block;
-  font-size: 3rem;
-  font-weight: 700;
-  color: #4fc949;
-  line-height: 1;
-  margin-bottom: 0.5rem;
-}
-
-.community-label {
-  display: block;
-  font-size: 1.125rem;
-  color: rgba(255, 255, 255, 0.9);
-  font-weight: 400;
-}
-
 /* CTA Buttons Group */
 .cta-buttons {
   display: flex;
@@ -141,14 +119,6 @@ footer a {
   .cta-buttons .actionbtn {
     width: 100%;
     max-width: 280px;
-  }
-
-  .community-size {
-    font-size: 2.5rem;
-  }
-
-  .community-label {
-    font-size: 1rem;
   }
 }
 

--- a/index.md
+++ b/index.md
@@ -20,11 +20,7 @@ ext-js:
 ## Ciência para todos! {#subtitle}
 
 #### A cientista lá do bairro na luta contra a desinformação científica em Portugal.
-
-<div class="social-proof">
-  <span class="community-size">4000+</span>
-  <span class="community-label">pessoas curiosas na nossa comunidade</span>
-</div>
+#### Uma comunidade de 4000+ pessoas curiosas e informadas
 
 <div class="cta-buttons">
   <a href="https://instagram.com/primatasdebata" class="actionbtn actionbtn-primary" target="_blank" rel="noopener">


### PR DESCRIPTION
## Summary
Simplifies the social proof display to match the formatting of surrounding text, removing special emphasis styling.

## Changes

### Before
```html
<div class="social-proof">
  <span class="community-size">4000+</span>
  <span class="community-label">pessoas curiosas na nossa comunidade</span>
</div>
```
With large green number (3rem font) and styled label.

### After
```markdown
#### Uma comunidade de 4000+ pessoas curiosas e informadas
```
Simple h4 text matching the style of the line above it.

### CSS Removed
```css
/* Social Proof */
.social-proof { ... }
.community-size { ... }
.community-label { ... }

/* Mobile responsive */
.community-size { font-size: 2.5rem; }
.community-label { font-size: 1rem; }
```
Total: 34 lines removed

## Rationale

The large emphasized "4000+" stood out too much and disrupted the visual flow of the header. Using a simple sentence format:
- Maintains consistency with surrounding text
- Provides the same information more naturally
- Reduces CSS complexity
- Looks cleaner and more professional

The member count is still prominent but not jarring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)